### PR TITLE
Fix BTSC-161

### DIFF
--- a/src/router/filter.ts
+++ b/src/router/filter.ts
@@ -50,7 +50,8 @@ filterRouter.get('/public', async (request: Request, response: Response) => {
         .select('count(p_v.id)')
         .from(Provider_Filter, 'p_v')
         .where('p_v.providerId = :providerId', { providerId })
-        .andWhere(`p_v.filterId = ${alias}.id`);
+        .andWhere(`p_v.filterId = ${alias}.id`)
+        .andWhere(`p.id <> :providerId`, { providerId });
     }, 'isImported')
     .andWhere(`${alias}.visibility = :visibility`, {
       visibility: Visibility.Public,
@@ -84,6 +85,7 @@ filterRouter.get('/public', async (request: Request, response: Response) => {
   });
 
   const mapper = {
+    providerId: `p.id`,
     providerName: `p.businessName`,
     providerCountry: `p.country`,
     cids: '"cidsCount"',
@@ -122,6 +124,7 @@ filterRouter.get('/public', async (request: Request, response: Response) => {
       cids: cids.length,
       subs: provider_Filters.length,
       provider,
+      providerId: provider.id,
       providerName: provider.businessName,
       providerCountry: provider.country,
     })
@@ -143,13 +146,13 @@ filterRouter.get(
           .select('count(p_v.id)')
           .from(Provider_Filter, 'p_v')
           .where('p_v.providerId = :providerId', { providerId })
-          .andWhere(`p_v.filterId = filter.id`);
+          .andWhere(`p_v.filterId = filter.id`)
+          .andWhere(`filter.provider.id != :providerId`, { providerId })
       }, 'isImported')
       .where('filter.id = :filterId', { filterId })
       .andWhere('filter.visibility = :visibility', {
         visibility: Visibility.Public,
       })
-      .andWhere('filter.provider.id != :providerId', { providerId })
       .loadAllRelationIds()
       .getRawAndEntities();
 


### PR DESCRIPTION
BTSC-161: 
* do not filter shared lists by current provider id
* adjust the `isImported` flag by comparing the current provider id (for both the directory and filter details pages)